### PR TITLE
Fix invalid icon includes in header

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -10,29 +10,20 @@
         <a aria-label="X (Twitter) – @danesherrets" target="_blank" rel="noopener noreferrer" href="https://x.com/danesherrets">
         </a>
       </div>
-      <div class="header-links">
-        <a class="pill" href="#press-mentions" data-scroll>
-          <span class="pill-icon">{% include icons/newspaper.svg %}</span>
-          <span class="pill-label">Press</span>
-        </a>
-        <a class="pill" href="#blog-posts" data-scroll>
-          <span class="pill-icon">{% include icons/pen.svg %}</span>
-          <span class="pill-label">Blog</span>
-        </a>
-        <a class="pill" href="#conference-talks" data-scroll>
-          <span class="pill-icon">{% include icons/mic.svg %}</span>
-          <span class="pill-icon">{% include_relative ../assets/icons/newspaper.svg %}</span>
-          <span class="pill-label">Press</span>
-        </a>
-        <a class="pill" href="#blog-posts" data-scroll>
-          <span class="pill-icon">{% include_relative ../assets/icons/pen.svg %}</span>
-          <span class="pill-label">Blog</span>
-        </a>
-        <a class="pill" href="#conference-talks" data-scroll>
-          <span class="pill-icon">{% include_relative ../assets/icons/mic.svg %}</span>
-          <span class="pill-label">Talks</span>
-        </a>
-      </div>
+        <div class="header-links">
+          <a class="pill" href="#press-mentions" data-scroll>
+            <span class="pill-icon">{% include icons/newspaper.svg %}</span>
+            <span class="pill-label">Press</span>
+          </a>
+          <a class="pill" href="#blog-posts" data-scroll>
+            <span class="pill-icon">{% include icons/pen.svg %}</span>
+            <span class="pill-label">Blog</span>
+          </a>
+          <a class="pill" href="#conference-talks" data-scroll>
+            <span class="pill-icon">{% include icons/mic.svg %}</span>
+            <span class="pill-label">Talks</span>
+          </a>
+        </div>
   </div>
   <a class="down" href="#press-mentions" data-scroll><i class="icon fa fa-chevron-down" aria-hidden="true"></i></a>
 </div>


### PR DESCRIPTION
## Summary
- remove `include_relative` tags pointing outside `_includes`
- keep only valid icon includes for Press, Blog, and Talks links

## Testing
- `jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_689b999e2a688322930a1d715f4d74eb