### PR TITLE
Add RSA podcast talk and Axios press mention

### DIFF
--- a/_includes/press.html
+++ b/_includes/press.html
@@ -13,7 +13,10 @@
     <img src="https://arstechnica.com/favicon.ico" alt="Ars Technica logo" loading="lazy">
   </a>
   <a href="https://www.foxbusiness.com/technology/ai-fueling-rise-cyberattacks" target="_blank" rel="noopener" class="press-logo" aria-label="Fox Business article">
-    <img src="https://www.foxbusiness.com/favicon.ico" alt="Fox Business logo" loading="lazy">
+    <img src="https://upload.wikimedia.org/wikipedia/commons/4/43/Fox_Business_logo_2020.svg" alt="Fox Business logo" loading="lazy">
+  </a>
+  <a href="https://www.axios.com/2025/02/28/ai-safety-rebrand-security-issues" target="_blank" rel="noopener" class="press-logo" aria-label="Axios article">
+    <img src="https://www.axios.com/favicon.ico" alt="Axios logo" loading="lazy">
   </a>
   <a href="https://www.darkreading.com/cyberattacks-data-breaches/green-bay-packers-online-pro-shop-payment-skimmer" target="_blank" rel="noopener" class="press-logo" aria-label="Dark Reading article">
     <img src="https://www.darkreading.com/favicon.ico" alt="Dark Reading logo" loading="lazy">

--- a/_includes/talks.html
+++ b/_includes/talks.html
@@ -22,5 +22,16 @@
       <a href="https://www.youtube.com/watch?v=6XzKgYF3kDU" class="talk-watch" target="_blank" rel="noopener" aria-label="Watch Securing the Human Voice in the Age of Deepfakes on YouTube">Watch</a>
     </div>
   </article>
+  <article class="talk-card">
+    <div class="talk-thumb">
+      <img src="/assets/img/rsa-logo.svg" alt="RSA Conference logo" loading="lazy">
+    </div>
+    <div class="talk-info">
+      <h3 class="talk-title">The World of AI</h3>
+      <p class="talk-event">RSA Conference Podcast</p>
+      <p class="talk-date">2024</p>
+      <a href="https://www.rsaconference.com/Library/podcast/2024-the-world-of-ai" class="talk-watch" target="_blank" rel="noopener" aria-label="Listen to The World of AI on RSA Conference">Listen</a>
+    </div>
+  </article>
 </div>
 

--- a/assets/img/rsa-logo.svg
+++ b/assets/img/rsa-logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 60">
+  <rect width="120" height="60" fill="#cc0000"/>
+  <text x="60" y="42" font-family="Arial, Helvetica, sans-serif" font-size="40" fill="#ffffff" text-anchor="middle">RSA</text>
+</svg>

--- a/src/img/rsa-logo.svg
+++ b/src/img/rsa-logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 60">
+  <rect width="120" height="60" fill="#cc0000"/>
+  <text x="60" y="42" font-family="Arial, Helvetica, sans-serif" font-size="40" fill="#ffffff" text-anchor="middle">RSA</text>
+</svg>


### PR DESCRIPTION
## Summary
- feature: add RSA Conference podcast entry to talks with logo
- fix: replace Fox Business logo for better hover and clarity
- feature: add Axios article to press section

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a7711156988322b70992c9124b30a2