### PR TITLE
Fix Fox Business icon and remove footer copyright

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,6 +1,3 @@
-<div class="footer-bottom">
-    <p>&copy; {{site.username}}</p>
-</div>
 <script defer src="https://cdn.jsdelivr.net/particles.js/2.0.0/particles.min.js"></script>
 <script defer src="/assets/js/sweet-scroll.min.js"></script>
 <script defer src="/assets/js/main.js"></script>

--- a/_includes/press.html
+++ b/_includes/press.html
@@ -13,7 +13,7 @@
     <img src="https://arstechnica.com/favicon.ico" alt="Ars Technica logo" loading="lazy">
   </a>
   <a href="https://www.foxbusiness.com/technology/ai-fueling-rise-cyberattacks" target="_blank" rel="noopener" class="press-logo" aria-label="Fox Business article">
-    <img src="https://upload.wikimedia.org/wikipedia/commons/4/43/Fox_Business_logo_2020.svg" alt="Fox Business logo" loading="lazy">
+    <img src="https://a57.foxnews.com/static.foxbusiness.com/foxbusiness.com/content/uploads/2020/06/0/0/38858313-fbnlogo.png?ve=1&tl=1" alt="Fox Business logo" loading="lazy">
   </a>
   <a href="https://www.axios.com/2025/02/28/ai-safety-rebrand-security-issues" target="_blank" rel="noopener" class="press-logo" aria-label="Axios article">
     <img src="https://www.axios.com/favicon.ico" alt="Axios logo" loading="lazy">

--- a/_site/index.html
+++ b/_site/index.html
@@ -59,7 +59,7 @@
   </div>
   <div class="press-item">
     <a href="https://www.foxbusiness.com/technology/ai-fueling-rise-cyberattacks" target="_blank">
-      <img src="https://www.foxbusiness.com/favicon.ico" alt="Fox Business logo"/>
+      <img src="https://a57.foxnews.com/static.foxbusiness.com/foxbusiness.com/content/uploads/2020/06/0/0/38858313-fbnlogo.png?ve=1&tl=1" alt="Fox Business logo"/>
     </a>
   </div>
   <div class="press-item">
@@ -106,7 +106,6 @@
         </section>
         
       <footer class="footer">
-    <p>&copy; Dane Sherrets</p>
  
 </footer>
 <script defer src="https://cdn.jsdelivr.net/particles.js/2.0.0/particles.min.js"></script>


### PR DESCRIPTION
## Summary
- Use working Fox Business logo URL in press mentions
- Drop copyright text referencing Dane Sherrets

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a78622ad848322b61d944027c97fac